### PR TITLE
fix(typing): limit supported data types to subclasses of `np.generic`

### DIFF
--- a/pydantic_numpy/helper/typing.py
+++ b/pydantic_numpy/helper/typing.py
@@ -1,4 +1,7 @@
+import numpy as np
 from typing_extensions import TypedDict
+
+SupportedDTypes = type[np.generic]
 
 
 class NumpyDataDict(TypedDict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydantic_numpy"
-version = "4.1.2"
+version = "4.1.3"
 description = "Pydantic Model integration of the NumPy array"
 authors = ["Can H. Tartanoglu", "Christoph Heindl"]
 maintainers = ["Can H. Tartanoglu <python@rotas.mozmail.com>"]

--- a/tests/helper/cache.py
+++ b/tests/helper/cache.py
@@ -2,10 +2,11 @@ from functools import cache
 from typing import Optional
 
 import numpy as np
-import numpy.typing as npt
 from hypothesis.extra.numpy import arrays
 from hypothesis.strategies import floats
 from pydantic import BaseModel
+
+from pydantic_numpy.helper.typing import SupportedDTypes
 
 
 @cache
@@ -17,7 +18,7 @@ def cached_calculation(array_type_hint) -> type[BaseModel]:
 
 
 @cache
-def cached_hyp_array(numpy_dtype: npt.DTypeLike, dimensions: Optional[int] = None, *, _axis_length: int = 1):
+def cached_hyp_array(numpy_dtype: SupportedDTypes, dimensions: Optional[int] = None, *, _axis_length: int = 1):
     if np.issubdtype(numpy_dtype, np.floating):
         if numpy_dtype == np.float16:
             width = 16


### PR DESCRIPTION
test: remove few `pyright: ignore` instructions where we previously failed for common Python types
chore: bump PATCH

---
Hello again! :)
Just a draft to start discussion as always. 
I think we've touched upon these `pyright` warnings that I've had too silence in a previous PR since deducted type was too wide and generic.
This commit fixes it and limits accepted `data_type` to subclasses of `np.generic` only. 
Thanks for looking into and let me know what you think! 