### PR TITLE
feat(NumpyModel): `__eq__` and dump/load support for nested NumpyModels

### DIFF
--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -1,0 +1,33 @@
+import tempfile
+from pydantic_numpy.model import NumpyModel
+from pydantic import Field
+import pydantic_numpy.typing as pnd
+import numpy as np
+from pathlib import Path
+
+
+class TestDump:
+    def test_multilevel_dump(self) -> None:
+        class A(NumpyModel):
+            a: pnd.NpNDArray = Field(frozen=True)
+        
+        class B(NumpyModel):
+            a: A = Field(frozen=True)
+        
+        class C(NumpyModel):
+            b: B = Field(frozen=True)
+        
+        a = A(a=np.zeros((2)))
+        b = B(a=a)
+        c = C(b=b)
+        
+        path = Path.home() / "test"
+        path.mkdir(exist_ok=True)
+        c.dump(path, "multilevel_model_test")
+        # with tempfile.TemporaryDirectory() as tmp:
+        #     print(tmp)
+        #     path = Path(tmp)
+        #     c.dump(path, "multilevel_model_test")
+            
+        new_c = C.load(path, "multilevel_model_test")
+        assert new_c == c

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -21,13 +21,9 @@ class TestDump:
         b = B(a=a)
         c = C(b=b)
         
-        path = Path.home() / "test"
-        path.mkdir(exist_ok=True)
-        c.dump(path, "multilevel_model_test")
-        # with tempfile.TemporaryDirectory() as tmp:
-        #     print(tmp)
-        #     path = Path(tmp)
-        #     c.dump(path, "multilevel_model_test")
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp)
+            c.dump(path, "multilevel_model_test")
             
-        new_c = C.load(path, "multilevel_model_test")
-        assert new_c == c
+            new_c = C.load(path, "multilevel_model_test")
+            assert new_c == c

--- a/tests/test_eq.py
+++ b/tests/test_eq.py
@@ -1,0 +1,23 @@
+from pydantic_numpy.model import NumpyModel
+from pydantic import Field
+import pydantic_numpy.typing as pnd
+import numpy as np
+
+
+class TestEQ:
+    def test_eq_multilevel(self) -> None:
+        class A(NumpyModel):
+            a: pnd.NpNDArray = Field(frozen=True)
+        
+        class B(NumpyModel):
+            a: A = Field(frozen=True)
+        
+        class C(NumpyModel):
+            b: B = Field(frozen=True)
+        
+        a = A(a=np.zeros((2)))
+        b = B(a=a)
+        c = C(b=b)
+
+        other_c = C(b=B(a=A(a=np.zeros((1)))))
+        assert c == other_c


### PR DESCRIPTION
Adds support for equality comparison and dump/load of nested NumpyModels.

The implementation is a recursive conversion of dicts of fields containing other dicts to a single "flat" dict matching fields to paths, which correspond nicely with file paths.

Fixes:
#25, #26