### PR TITLE
Fix #44 by comparing all fields not just the changed fields

### DIFF
--- a/pydantic_numpy/model.py
+++ b/pydantic_numpy/model.py
@@ -49,8 +49,9 @@ class NumpyModel(BaseModel):
             self_type = self.__pydantic_generic_metadata__["origin"] or self.__class__
             other_type = other.__pydantic_generic_metadata__["origin"] or other.__class__
 
-            self_ndarray_field_to_array, self_other_field_to_value = self._dump_numpy_split_dict()
-            other_ndarray_field_to_array, other_other_field_to_value = other._dump_numpy_split_dict()
+            # Pass through exclude_unset=False since it's important we compare all fields in equality
+            self_ndarray_field_to_array, self_other_field_to_value = self._dump_numpy_split_dict(exclude_unset=False)
+            other_ndarray_field_to_array, other_other_field_to_value = other._dump_numpy_split_dict(exclude_unset=False)
 
             return (
                 self_type == other_type
@@ -152,11 +153,11 @@ class NumpyModel(BaseModel):
 
         return dump_directory_path
 
-    def _dump_numpy_split_dict(self) -> tuple[dict, dict]:
+    def _dump_numpy_split_dict(self, exclude_unset=True) -> tuple[dict, dict]:
         ndarray_field_to_array = {}
         other_field_to_value = {}
 
-        for k, v in self.model_dump(exclude_unset=True).items():
+        for k, v in self.model_dump(exclude_unset=exclude_unset).items():
             if isinstance(v, np.ndarray):
                 ndarray_field_to_array[k] = v
             else:

--- a/tests/test_ser_deser.py
+++ b/tests/test_ser_deser.py
@@ -1,0 +1,29 @@
+import unittest
+
+import numpy as np
+
+from pydantic_numpy.typing import NpNDArrayFp64, NpNDArrayInt64    
+from pydantic_numpy.model import NumpyModel
+
+class TestSerDeser(unittest.TestCase):
+    def test_can_ser_and_deser_basic_numpy_to_json(self):
+
+        # Given
+        class NumpyData(NumpyModel):
+            array_float: NpNDArrayFp64 = np.linspace(0.0, 1.0, 20)
+            array_int: NpNDArrayInt64 = np.arange(100)
+
+        data = NumpyData()
+        
+        # When
+        ser = data.model_dump_json()
+        data_read_correct = NumpyData.model_validate_json(ser)
+        data_read_incorrect = NumpyData.model_validate_json(ser)
+        data_read_incorrect.array_float[0] = 1.5
+        
+        # Then
+        assert data == data_read_correct
+        assert not data == data_read_incorrect
+        
+
+        

--- a/tests/test_ser_deser.py
+++ b/tests/test_ser_deser.py
@@ -6,7 +6,7 @@ from pydantic_numpy.typing import NpNDArrayFp64, NpNDArrayInt64
 from pydantic_numpy.model import NumpyModel
 
 class TestSerDeser(unittest.TestCase):
-    def test_can_ser_and_deser_basic_numpy_to_json(self):
+    def test_can_ser_and_deser_basic_numpy_to_json_and_compare(self):
 
         # Given
         class NumpyData(NumpyModel):


### PR DESCRIPTION
When deserialising it believes that all fields are unset which means a comparison serialise, deserialise, compare always fails. This fixes that by comparing all fields during the equality operator. 