### PR TITLE
fix(typegen): use "strict" type notation for all generated types

### DIFF
--- a/pydantic_numpy/typing/i_dimensional.py
+++ b/pydantic_numpy/typing/i_dimensional.py
@@ -1,103 +1,101 @@
-from typing import Annotated, Any, Union
+from typing import Annotated, Any
 
 import numpy as np
-from pydantic import FilePath
 
 from pydantic_numpy.helper.annotation import NpArrayPydanticAnnotation
-from pydantic_numpy.model import MultiArrayNumpyFile
 
 Np1DArray = Annotated[
-    Union[np.ndarray[tuple[int], np.dtype[Any]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int], np.dtype[Any]],
     NpArrayPydanticAnnotation.factory(data_type=None, dimensions=1, strict_data_typing=False),
 ]
 
 Np1DArrayInt64 = Annotated[
-    Union[np.ndarray[tuple[int], np.dtype[np.int64]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int], np.dtype[np.int64]],
     NpArrayPydanticAnnotation.factory(data_type=np.int64, dimensions=1, strict_data_typing=False),
 ]
 
 Np1DArrayInt32 = Annotated[
-    Union[np.ndarray[tuple[int], np.dtype[np.int32]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int], np.dtype[np.int32]],
     NpArrayPydanticAnnotation.factory(data_type=np.int32, dimensions=1, strict_data_typing=False),
 ]
 
 Np1DArrayInt16 = Annotated[
-    Union[np.ndarray[tuple[int], np.dtype[np.int16]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int], np.dtype[np.int16]],
     NpArrayPydanticAnnotation.factory(data_type=np.int16, dimensions=1, strict_data_typing=False),
 ]
 
 Np1DArrayInt8 = Annotated[
-    Union[np.ndarray[tuple[int], np.dtype[np.int8]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int], np.dtype[np.int8]],
     NpArrayPydanticAnnotation.factory(data_type=np.int8, dimensions=1, strict_data_typing=False),
 ]
 
 Np1DArrayUint64 = Annotated[
-    Union[np.ndarray[tuple[int], np.dtype[np.uint64]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int], np.dtype[np.uint64]],
     NpArrayPydanticAnnotation.factory(data_type=np.uint64, dimensions=1, strict_data_typing=False),
 ]
 
 Np1DArrayUint32 = Annotated[
-    Union[np.ndarray[tuple[int], np.dtype[np.uint32]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int], np.dtype[np.uint32]],
     NpArrayPydanticAnnotation.factory(data_type=np.uint32, dimensions=1, strict_data_typing=False),
 ]
 
 Np1DArrayUint16 = Annotated[
-    Union[np.ndarray[tuple[int], np.dtype[np.uint16]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int], np.dtype[np.uint16]],
     NpArrayPydanticAnnotation.factory(data_type=np.uint16, dimensions=1, strict_data_typing=False),
 ]
 
 Np1DArrayUint8 = Annotated[
-    Union[np.ndarray[tuple[int], np.dtype[np.uint8]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int], np.dtype[np.uint8]],
     NpArrayPydanticAnnotation.factory(data_type=np.uint8, dimensions=1, strict_data_typing=False),
 ]
 
 Np1DArrayFpLongDouble = Annotated[
-    Union[np.ndarray[tuple[int], np.dtype[np.longdouble]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int], np.dtype[np.longdouble]],
     NpArrayPydanticAnnotation.factory(data_type=np.longdouble, dimensions=1, strict_data_typing=False),
 ]
 
 Np1DArrayFp64 = Annotated[
-    Union[np.ndarray[tuple[int], np.dtype[np.float64]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int], np.dtype[np.float64]],
     NpArrayPydanticAnnotation.factory(data_type=np.float64, dimensions=1, strict_data_typing=False),
 ]
 
 Np1DArrayFp32 = Annotated[
-    Union[np.ndarray[tuple[int], np.dtype[np.float32]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int], np.dtype[np.float32]],
     NpArrayPydanticAnnotation.factory(data_type=np.float32, dimensions=1, strict_data_typing=False),
 ]
 
 Np1DArrayFp16 = Annotated[
-    Union[np.ndarray[tuple[int], np.dtype[np.float16]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int], np.dtype[np.float16]],
     NpArrayPydanticAnnotation.factory(data_type=np.float16, dimensions=1, strict_data_typing=False),
 ]
 
 Np1DArrayComplexLongDouble = Annotated[
-    Union[np.ndarray[tuple[int], np.dtype[np.clongdouble]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int], np.dtype[np.clongdouble]],
     NpArrayPydanticAnnotation.factory(data_type=np.clongdouble, dimensions=1, strict_data_typing=False),
 ]
 
 Np1DArrayComplex128 = Annotated[
-    Union[np.ndarray[tuple[int], np.dtype[np.complex128]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int], np.dtype[np.complex128]],
     NpArrayPydanticAnnotation.factory(data_type=np.complex128, dimensions=1, strict_data_typing=False),
 ]
 
 Np1DArrayComplex64 = Annotated[
-    Union[np.ndarray[tuple[int], np.dtype[np.complex64]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int], np.dtype[np.complex64]],
     NpArrayPydanticAnnotation.factory(data_type=np.complex64, dimensions=1, strict_data_typing=False),
 ]
 
 Np1DArrayBool = Annotated[
-    Union[np.ndarray[tuple[int], np.dtype[np.bool_]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int], np.dtype[np.bool_]],
     NpArrayPydanticAnnotation.factory(data_type=np.bool_, dimensions=1, strict_data_typing=False),
 ]
 
 Np1DArrayDatetime64 = Annotated[
-    Union[np.ndarray[tuple[int], np.dtype[np.datetime64]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int], np.dtype[np.datetime64]],
     NpArrayPydanticAnnotation.factory(data_type=np.datetime64, dimensions=1, strict_data_typing=False),
 ]
 
 Np1DArrayTimedelta64 = Annotated[
-    Union[np.ndarray[tuple[int], np.dtype[np.timedelta64]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int], np.dtype[np.timedelta64]],
     NpArrayPydanticAnnotation.factory(data_type=np.timedelta64, dimensions=1, strict_data_typing=False),
 ]
 

--- a/pydantic_numpy/typing/ii_dimensional.py
+++ b/pydantic_numpy/typing/ii_dimensional.py
@@ -1,103 +1,101 @@
-from typing import Annotated, Any, Union
+from typing import Annotated, Any
 
 import numpy as np
-from pydantic import FilePath
 
 from pydantic_numpy.helper.annotation import NpArrayPydanticAnnotation
-from pydantic_numpy.model import MultiArrayNumpyFile
 
 Np2DArray = Annotated[
-    Union[np.ndarray[tuple[int, int], np.dtype[Any]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int], np.dtype[Any]],
     NpArrayPydanticAnnotation.factory(data_type=None, dimensions=2, strict_data_typing=False),
 ]
 
 Np2DArrayInt64 = Annotated[
-    Union[np.ndarray[tuple[int, int], np.dtype[np.int64]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int], np.dtype[np.int64]],
     NpArrayPydanticAnnotation.factory(data_type=np.int64, dimensions=2, strict_data_typing=False),
 ]
 
 Np2DArrayInt32 = Annotated[
-    Union[np.ndarray[tuple[int, int], np.dtype[np.int32]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int], np.dtype[np.int32]],
     NpArrayPydanticAnnotation.factory(data_type=np.int32, dimensions=2, strict_data_typing=False),
 ]
 
 Np2DArrayInt16 = Annotated[
-    Union[np.ndarray[tuple[int, int], np.dtype[np.int16]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int], np.dtype[np.int16]],
     NpArrayPydanticAnnotation.factory(data_type=np.int16, dimensions=2, strict_data_typing=False),
 ]
 
 Np2DArrayInt8 = Annotated[
-    Union[np.ndarray[tuple[int, int], np.dtype[np.int8]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int], np.dtype[np.int8]],
     NpArrayPydanticAnnotation.factory(data_type=np.int8, dimensions=2, strict_data_typing=False),
 ]
 
 Np2DArrayUint64 = Annotated[
-    Union[np.ndarray[tuple[int, int], np.dtype[np.uint64]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int], np.dtype[np.uint64]],
     NpArrayPydanticAnnotation.factory(data_type=np.uint64, dimensions=2, strict_data_typing=False),
 ]
 
 Np2DArrayUint32 = Annotated[
-    Union[np.ndarray[tuple[int, int], np.dtype[np.uint32]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int], np.dtype[np.uint32]],
     NpArrayPydanticAnnotation.factory(data_type=np.uint32, dimensions=2, strict_data_typing=False),
 ]
 
 Np2DArrayUint16 = Annotated[
-    Union[np.ndarray[tuple[int, int], np.dtype[np.uint16]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int], np.dtype[np.uint16]],
     NpArrayPydanticAnnotation.factory(data_type=np.uint16, dimensions=2, strict_data_typing=False),
 ]
 
 Np2DArrayUint8 = Annotated[
-    Union[np.ndarray[tuple[int, int], np.dtype[np.uint8]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int], np.dtype[np.uint8]],
     NpArrayPydanticAnnotation.factory(data_type=np.uint8, dimensions=2, strict_data_typing=False),
 ]
 
 Np2DArrayFpLongDouble = Annotated[
-    Union[np.ndarray[tuple[int, int], np.dtype[np.longdouble]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int], np.dtype[np.longdouble]],
     NpArrayPydanticAnnotation.factory(data_type=np.longdouble, dimensions=2, strict_data_typing=False),
 ]
 
 Np2DArrayFp64 = Annotated[
-    Union[np.ndarray[tuple[int, int], np.dtype[np.float64]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int], np.dtype[np.float64]],
     NpArrayPydanticAnnotation.factory(data_type=np.float64, dimensions=2, strict_data_typing=False),
 ]
 
 Np2DArrayFp32 = Annotated[
-    Union[np.ndarray[tuple[int, int], np.dtype[np.float32]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int], np.dtype[np.float32]],
     NpArrayPydanticAnnotation.factory(data_type=np.float32, dimensions=2, strict_data_typing=False),
 ]
 
 Np2DArrayFp16 = Annotated[
-    Union[np.ndarray[tuple[int, int], np.dtype[np.float16]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int], np.dtype[np.float16]],
     NpArrayPydanticAnnotation.factory(data_type=np.float16, dimensions=2, strict_data_typing=False),
 ]
 
 Np2DArrayComplexLongDouble = Annotated[
-    Union[np.ndarray[tuple[int, int], np.dtype[np.clongdouble]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int], np.dtype[np.clongdouble]],
     NpArrayPydanticAnnotation.factory(data_type=np.clongdouble, dimensions=2, strict_data_typing=False),
 ]
 
 Np2DArrayComplex128 = Annotated[
-    Union[np.ndarray[tuple[int, int], np.dtype[np.complex128]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int], np.dtype[np.complex128]],
     NpArrayPydanticAnnotation.factory(data_type=np.complex128, dimensions=2, strict_data_typing=False),
 ]
 
 Np2DArrayComplex64 = Annotated[
-    Union[np.ndarray[tuple[int, int], np.dtype[np.complex64]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int], np.dtype[np.complex64]],
     NpArrayPydanticAnnotation.factory(data_type=np.complex64, dimensions=2, strict_data_typing=False),
 ]
 
 Np2DArrayBool = Annotated[
-    Union[np.ndarray[tuple[int, int], np.dtype[np.bool_]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int], np.dtype[np.bool_]],
     NpArrayPydanticAnnotation.factory(data_type=np.bool_, dimensions=2, strict_data_typing=False),
 ]
 
 Np2DArrayDatetime64 = Annotated[
-    Union[np.ndarray[tuple[int, int], np.dtype[np.datetime64]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int], np.dtype[np.datetime64]],
     NpArrayPydanticAnnotation.factory(data_type=np.datetime64, dimensions=2, strict_data_typing=False),
 ]
 
 Np2DArrayTimedelta64 = Annotated[
-    Union[np.ndarray[tuple[int, int], np.dtype[np.timedelta64]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int], np.dtype[np.timedelta64]],
     NpArrayPydanticAnnotation.factory(data_type=np.timedelta64, dimensions=2, strict_data_typing=False),
 ]
 

--- a/pydantic_numpy/typing/iii_dimensional.py
+++ b/pydantic_numpy/typing/iii_dimensional.py
@@ -1,103 +1,101 @@
-from typing import Annotated, Any, Union
+from typing import Annotated, Any
 
 import numpy as np
-from pydantic import FilePath
 
 from pydantic_numpy.helper.annotation import NpArrayPydanticAnnotation
-from pydantic_numpy.model import MultiArrayNumpyFile
 
 Np3DArray = Annotated[
-    Union[np.ndarray[tuple[int, int, int], np.dtype[Any]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int, int], np.dtype[Any]],
     NpArrayPydanticAnnotation.factory(data_type=None, dimensions=3, strict_data_typing=False),
 ]
 
 Np3DArrayInt64 = Annotated[
-    Union[np.ndarray[tuple[int, int, int], np.dtype[np.int64]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int, int], np.dtype[np.int64]],
     NpArrayPydanticAnnotation.factory(data_type=np.int64, dimensions=3, strict_data_typing=False),
 ]
 
 Np3DArrayInt32 = Annotated[
-    Union[np.ndarray[tuple[int, int, int], np.dtype[np.int32]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int, int], np.dtype[np.int32]],
     NpArrayPydanticAnnotation.factory(data_type=np.int32, dimensions=3, strict_data_typing=False),
 ]
 
 Np3DArrayInt16 = Annotated[
-    Union[np.ndarray[tuple[int, int, int], np.dtype[np.int16]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int, int], np.dtype[np.int16]],
     NpArrayPydanticAnnotation.factory(data_type=np.int16, dimensions=3, strict_data_typing=False),
 ]
 
 Np3DArrayInt8 = Annotated[
-    Union[np.ndarray[tuple[int, int, int], np.dtype[np.int8]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int, int], np.dtype[np.int8]],
     NpArrayPydanticAnnotation.factory(data_type=np.int8, dimensions=3, strict_data_typing=False),
 ]
 
 Np3DArrayUint64 = Annotated[
-    Union[np.ndarray[tuple[int, int, int], np.dtype[np.uint64]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int, int], np.dtype[np.uint64]],
     NpArrayPydanticAnnotation.factory(data_type=np.uint64, dimensions=3, strict_data_typing=False),
 ]
 
 Np3DArrayUint32 = Annotated[
-    Union[np.ndarray[tuple[int, int, int], np.dtype[np.uint32]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int, int], np.dtype[np.uint32]],
     NpArrayPydanticAnnotation.factory(data_type=np.uint32, dimensions=3, strict_data_typing=False),
 ]
 
 Np3DArrayUint16 = Annotated[
-    Union[np.ndarray[tuple[int, int, int], np.dtype[np.uint16]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int, int], np.dtype[np.uint16]],
     NpArrayPydanticAnnotation.factory(data_type=np.uint16, dimensions=3, strict_data_typing=False),
 ]
 
 Np3DArrayUint8 = Annotated[
-    Union[np.ndarray[tuple[int, int, int], np.dtype[np.uint8]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int, int], np.dtype[np.uint8]],
     NpArrayPydanticAnnotation.factory(data_type=np.uint8, dimensions=3, strict_data_typing=False),
 ]
 
 Np3DArrayFpLongDouble = Annotated[
-    Union[np.ndarray[tuple[int, int, int], np.dtype[np.longdouble]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int, int], np.dtype[np.longdouble]],
     NpArrayPydanticAnnotation.factory(data_type=np.longdouble, dimensions=3, strict_data_typing=False),
 ]
 
 Np3DArrayFp64 = Annotated[
-    Union[np.ndarray[tuple[int, int, int], np.dtype[np.float64]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int, int], np.dtype[np.float64]],
     NpArrayPydanticAnnotation.factory(data_type=np.float64, dimensions=3, strict_data_typing=False),
 ]
 
 Np3DArrayFp32 = Annotated[
-    Union[np.ndarray[tuple[int, int, int], np.dtype[np.float32]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int, int], np.dtype[np.float32]],
     NpArrayPydanticAnnotation.factory(data_type=np.float32, dimensions=3, strict_data_typing=False),
 ]
 
 Np3DArrayFp16 = Annotated[
-    Union[np.ndarray[tuple[int, int, int], np.dtype[np.float16]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int, int], np.dtype[np.float16]],
     NpArrayPydanticAnnotation.factory(data_type=np.float16, dimensions=3, strict_data_typing=False),
 ]
 
 Np3DArrayComplexLongDouble = Annotated[
-    Union[np.ndarray[tuple[int, int, int], np.dtype[np.clongdouble]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int, int], np.dtype[np.clongdouble]],
     NpArrayPydanticAnnotation.factory(data_type=np.clongdouble, dimensions=3, strict_data_typing=False),
 ]
 
 Np3DArrayComplex128 = Annotated[
-    Union[np.ndarray[tuple[int, int, int], np.dtype[np.complex128]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int, int], np.dtype[np.complex128]],
     NpArrayPydanticAnnotation.factory(data_type=np.complex128, dimensions=3, strict_data_typing=False),
 ]
 
 Np3DArrayComplex64 = Annotated[
-    Union[np.ndarray[tuple[int, int, int], np.dtype[np.complex64]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int, int], np.dtype[np.complex64]],
     NpArrayPydanticAnnotation.factory(data_type=np.complex64, dimensions=3, strict_data_typing=False),
 ]
 
 Np3DArrayBool = Annotated[
-    Union[np.ndarray[tuple[int, int, int], np.dtype[np.bool_]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int, int], np.dtype[np.bool_]],
     NpArrayPydanticAnnotation.factory(data_type=np.bool_, dimensions=3, strict_data_typing=False),
 ]
 
 Np3DArrayDatetime64 = Annotated[
-    Union[np.ndarray[tuple[int, int, int], np.dtype[np.datetime64]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int, int], np.dtype[np.datetime64]],
     NpArrayPydanticAnnotation.factory(data_type=np.datetime64, dimensions=3, strict_data_typing=False),
 ]
 
 Np3DArrayTimedelta64 = Annotated[
-    Union[np.ndarray[tuple[int, int, int], np.dtype[np.timedelta64]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[tuple[int, int, int], np.dtype[np.timedelta64]],
     NpArrayPydanticAnnotation.factory(data_type=np.timedelta64, dimensions=3, strict_data_typing=False),
 ]
 

--- a/pydantic_numpy/typing/n_dimensional.py
+++ b/pydantic_numpy/typing/n_dimensional.py
@@ -1,103 +1,101 @@
-from typing import Annotated, Any, Union
+from typing import Annotated, Any
 
 import numpy as np
-from pydantic import FilePath
 
 from pydantic_numpy.helper.annotation import NpArrayPydanticAnnotation
-from pydantic_numpy.model import MultiArrayNumpyFile
 
 NpNDArray = Annotated[
-    Union[np.ndarray[Any, np.dtype[Any]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[Any, np.dtype[Any]],
     NpArrayPydanticAnnotation.factory(data_type=None, dimensions=None, strict_data_typing=False),
 ]
 
 NpNDArrayInt64 = Annotated[
-    Union[np.ndarray[Any, np.dtype[np.int64]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[Any, np.dtype[np.int64]],
     NpArrayPydanticAnnotation.factory(data_type=np.int64, dimensions=None, strict_data_typing=False),
 ]
 
 NpNDArrayInt32 = Annotated[
-    Union[np.ndarray[Any, np.dtype[np.int32]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[Any, np.dtype[np.int32]],
     NpArrayPydanticAnnotation.factory(data_type=np.int32, dimensions=None, strict_data_typing=False),
 ]
 
 NpNDArrayInt16 = Annotated[
-    Union[np.ndarray[Any, np.dtype[np.int16]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[Any, np.dtype[np.int16]],
     NpArrayPydanticAnnotation.factory(data_type=np.int16, dimensions=None, strict_data_typing=False),
 ]
 
 NpNDArrayInt8 = Annotated[
-    Union[np.ndarray[Any, np.dtype[np.int8]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[Any, np.dtype[np.int8]],
     NpArrayPydanticAnnotation.factory(data_type=np.int8, dimensions=None, strict_data_typing=False),
 ]
 
 NpNDArrayUint64 = Annotated[
-    Union[np.ndarray[Any, np.dtype[np.uint64]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[Any, np.dtype[np.uint64]],
     NpArrayPydanticAnnotation.factory(data_type=np.uint64, dimensions=None, strict_data_typing=False),
 ]
 
 NpNDArrayUint32 = Annotated[
-    Union[np.ndarray[Any, np.dtype[np.uint32]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[Any, np.dtype[np.uint32]],
     NpArrayPydanticAnnotation.factory(data_type=np.uint32, dimensions=None, strict_data_typing=False),
 ]
 
 NpNDArrayUint16 = Annotated[
-    Union[np.ndarray[Any, np.dtype[np.uint16]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[Any, np.dtype[np.uint16]],
     NpArrayPydanticAnnotation.factory(data_type=np.uint16, dimensions=None, strict_data_typing=False),
 ]
 
 NpNDArrayUint8 = Annotated[
-    Union[np.ndarray[Any, np.dtype[np.uint8]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[Any, np.dtype[np.uint8]],
     NpArrayPydanticAnnotation.factory(data_type=np.uint8, dimensions=None, strict_data_typing=False),
 ]
 
 NpNDArrayFpLongDouble = Annotated[
-    Union[np.ndarray[Any, np.dtype[np.longdouble]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[Any, np.dtype[np.longdouble]],
     NpArrayPydanticAnnotation.factory(data_type=np.longdouble, dimensions=None, strict_data_typing=False),
 ]
 
 NpNDArrayFp64 = Annotated[
-    Union[np.ndarray[Any, np.dtype[np.float64]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[Any, np.dtype[np.float64]],
     NpArrayPydanticAnnotation.factory(data_type=np.float64, dimensions=None, strict_data_typing=False),
 ]
 
 NpNDArrayFp32 = Annotated[
-    Union[np.ndarray[Any, np.dtype[np.float32]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[Any, np.dtype[np.float32]],
     NpArrayPydanticAnnotation.factory(data_type=np.float32, dimensions=None, strict_data_typing=False),
 ]
 
 NpNDArrayFp16 = Annotated[
-    Union[np.ndarray[Any, np.dtype[np.float16]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[Any, np.dtype[np.float16]],
     NpArrayPydanticAnnotation.factory(data_type=np.float16, dimensions=None, strict_data_typing=False),
 ]
 
 NpNDArrayComplexLongDouble = Annotated[
-    Union[np.ndarray[Any, np.dtype[np.clongdouble]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[Any, np.dtype[np.clongdouble]],
     NpArrayPydanticAnnotation.factory(data_type=np.clongdouble, dimensions=None, strict_data_typing=False),
 ]
 
 NpNDArrayComplex128 = Annotated[
-    Union[np.ndarray[Any, np.dtype[np.complex128]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[Any, np.dtype[np.complex128]],
     NpArrayPydanticAnnotation.factory(data_type=np.complex128, dimensions=None, strict_data_typing=False),
 ]
 
 NpNDArrayComplex64 = Annotated[
-    Union[np.ndarray[Any, np.dtype[np.complex64]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[Any, np.dtype[np.complex64]],
     NpArrayPydanticAnnotation.factory(data_type=np.complex64, dimensions=None, strict_data_typing=False),
 ]
 
 NpNDArrayBool = Annotated[
-    Union[np.ndarray[Any, np.dtype[np.bool_]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[Any, np.dtype[np.bool_]],
     NpArrayPydanticAnnotation.factory(data_type=np.bool_, dimensions=None, strict_data_typing=False),
 ]
 
 NpNDArrayDatetime64 = Annotated[
-    Union[np.ndarray[Any, np.dtype[np.datetime64]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[Any, np.dtype[np.datetime64]],
     NpArrayPydanticAnnotation.factory(data_type=np.datetime64, dimensions=None, strict_data_typing=False),
 ]
 
 NpNDArrayTimedelta64 = Annotated[
-    Union[np.ndarray[Any, np.dtype[np.timedelta64]], FilePath, MultiArrayNumpyFile],
+    np.ndarray[Any, np.dtype[np.timedelta64]],
     NpArrayPydanticAnnotation.factory(data_type=np.timedelta64, dimensions=None, strict_data_typing=False),
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydantic_numpy"
-version = "7.0.0"
+version = "7.1.0"
 description = "Pydantic Model integration of the NumPy array"
 authors = ["Can H. Tartanoglu", "Christoph Heindl"]
 maintainers = ["Can H. Tartanoglu <python@rotas.mozmail.com>"]

--- a/typegen/generate_typing.py
+++ b/typegen/generate_typing.py
@@ -94,12 +94,8 @@ def _type_name_with_prefix(dimensions: int, type_name: str, strict: bool) -> str
     return f"Np{strict_prefix}{dimension_prefix}{type_name}"
 
 
-def _strict_type(dimension_type: str, dtype: str) -> str:
+def _type_hint(dimension_type: str, dtype: str) -> str:
     return f"np.ndarray[{dimension_type}, np.dtype[{dtype}]]"
-
-
-def _union_type(dimension_type: str, dtype: str) -> str:
-    return f"Union[np.ndarray[{dimension_type}, np.dtype[{dtype}]], FilePath, MultiArrayNumpyFile]"
 
 
 def _annotate_type(dimensions: int, type_name: str, strict: bool) -> str:
@@ -110,7 +106,7 @@ def _annotate_type(dimensions: int, type_name: str, strict: bool) -> str:
         return ""
 
     dtype = "Any" if data_type == "None" else data_type
-    T = _strict_type(dimension_type, dtype) if strict else _union_type(dimension_type, dtype)
+    T = _type_hint(dimension_type, dtype)
     dim = dimensions if dimensions > 0 else None
     annotation = f"""{type_with_prefix} = Annotated[
         {T},
@@ -138,13 +134,11 @@ __all__ = [
 
 
 def _generate_union_template(dimensions: int, contents: str, all_types: str) -> str:
-    template = f"""from typing import Annotated, Any, Union
+    template = f"""from typing import Annotated, Any
 
 import numpy as np
-from pydantic import FilePath
 
 from pydantic_numpy.helper.annotation import NpArrayPydanticAnnotation
-from pydantic_numpy.model import MultiArrayNumpyFile
 
 {contents.strip()}
 


### PR DESCRIPTION
Let our models always represent types after validation and coercion.
This fixes static analysis errors (pyright) and issue #55. 

chore(version): bump MINOR